### PR TITLE
[feat/booking] 예약 기능 구현

### DIFF
--- a/src/assets/index.js
+++ b/src/assets/index.js
@@ -18,5 +18,3 @@ export { default as icMedal } from './icons/ic_medal.svg';
 export { default as icPin } from './icons/ic_pin.svg';
 export { default as icPlus } from './icons/ic_plus.svg';
 export { default as imgRoom } from './images/img_room.svg';
-
-export { default as icLoading } from './icons/ic_loading.svg';

--- a/src/components/common/NavBar.jsx
+++ b/src/components/common/NavBar.jsx
@@ -9,7 +9,7 @@ function NavBar() {
         <img src={icSearch} />
         <span>둘러보기</span>
       </StyledNavToggle>
-      <Link to="/Wish">
+      <Link to="/Wishlist">
         <StyledNavToggle>
           <img src={icWish} />
           <span>위시리스트</span>
@@ -67,6 +67,7 @@ const StyledNavToggle = styled.div`
   &:hover {
     span {
       color: ${(props) => props.theme.colors.airBlack};
+      font-weight: bold;
     }
   }
   img {

--- a/src/components/common/NavBar.jsx
+++ b/src/components/common/NavBar.jsx
@@ -9,7 +9,7 @@ function NavBar() {
         <img src={icSearch} />
         <span>둘러보기</span>
       </StyledNavToggle>
-      <Link to="/Wishlist">
+      <Link to="/wishlist">
         <StyledNavToggle>
           <img src={icWish} />
           <span>위시리스트</span>

--- a/src/components/common/Router.js
+++ b/src/components/common/Router.js
@@ -1,5 +1,4 @@
 import Home from 'pages/Home';
-import Wish from 'pages/Wish';
 import Room from 'pages/Room';
 import WishList from 'pages/WishList';
 import React from 'react';
@@ -14,7 +13,6 @@ function Router() {
         <Route path="/" element={<Home />} />
         <Route path="/wishlist" element={<WishList />} />
         <Route path="/room/:id" element={<Room />} />
-        <Route path="/wish" element={<Wish />} />
         <Route path="/*" element={<p>Page Not Found</p>} />
       </Routes>
     </BrowserRouter>

--- a/src/components/home/FirstSection.jsx
+++ b/src/components/home/FirstSection.jsx
@@ -31,7 +31,7 @@ const StyledIsBooked = styled.section`
   height: 27.6rem;
 
   background: #ffffff;
-  border: 1px solid ${(props) => props.theme.colors.airGray2};
+  border: 0.1rem solid ${(props) => props.theme.colors.airGray2};
   border-radius: 1rem;
   filter: drop-shadow(0.4rem 0.4rem 2rem rgba(0, 0, 0, 0.15));
 
@@ -70,7 +70,7 @@ const StyledFirstSection = styled.section`
   height: 24.1rem;
 
   background: #ffffff;
-  border: 1px solid ${(props) => props.theme.colors.airGray2};
+  border: 0.1rem solid ${(props) => props.theme.colors.airGray2};
   border-radius: 1rem;
 
   button {

--- a/src/components/home/FirstSection.jsx
+++ b/src/components/home/FirstSection.jsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import styled from 'styled-components';
+import { icHand, imgRoom } from 'assets';
+
+function FirstSection({ title, host }) {
+  if (title === 'unBooked') {
+    return (
+      <StyledFirstSection>
+        <StyledIcHand src={icHand} />
+        <span>아직 예약된 여행이 없습니다!</span>
+        <StyledSearchButton>숙소 검색하기</StyledSearchButton>
+      </StyledFirstSection>
+    );
+  } else {
+    return (
+      <StyledIsBooked>
+        <img src={imgRoom} />
+        <p>{title}</p>
+        <span>{host} 님이 호스팅 하는 집 전체</span>
+      </StyledIsBooked>
+    );
+  }
+}
+
+export default FirstSection;
+
+const StyledIsBooked = styled.section`
+  margin: 0;
+  box-sizing: border-box;
+  width: 33.1rem;
+  height: 27.6rem;
+
+  background: #ffffff;
+  border: 1px solid ${(props) => props.theme.colors.airGray2};
+  border-radius: 1rem;
+  filter: drop-shadow(4px 4px 20px rgba(0, 0, 0, 0.15));
+
+  img {
+    width: 32.9rem;
+    height: 14.8rem;
+    object-fit: cover;
+    border-top-left-radius: 1rem;
+    border-top-right-radius: 1rem;
+  }
+
+  p {
+    font-weight: 500;
+    font-size: 2.4rem;
+    line-height: 2.6rem;
+    margin: 2.2rem 2rem 0.8rem 2rem;
+    font-family: 'AirbnbCereal_W_Md';
+  }
+  span {
+    font-weight: 500;
+    font-size: 1.2rem;
+    line-height: 1.4rem;
+
+    margin-left: 2rem;
+    margin-bottom: 3.2rem;
+  }
+`;
+
+const StyledFirstSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  box-sizing: border-box;
+  width: 33.1rem;
+  height: 24.1rem;
+
+  background: #ffffff;
+  border: 1px solid ${(props) => props.theme.colors.airGray2};
+  border-radius: 1rem;
+
+  button {
+    background-color: ${(props) => props.theme.colors.airPink};
+    color: ${(props) => props.theme.colors.airWhite};
+  }
+
+  span {
+    margin-top: 2rem;
+
+    font-weight: 600;
+    font-size: 1.6rem;
+    line-height: 1.9rem;
+  }
+`;
+
+const StyledIcHand = styled.img`
+  width: 4rem;
+  height: 4rem;
+  margin-top: 4.8rem;
+`;
+
+const StyledSearchButton = styled.button`
+  margin-top: 4.8rem;
+
+  width: 28.6rem;
+  height: 4.4rem;
+  border-radius: 6px;
+
+  font-weight: 600;
+  font-size: 1.6rem;
+  line-height: 1.9rem;
+`;

--- a/src/components/home/FirstSection.jsx
+++ b/src/components/home/FirstSection.jsx
@@ -3,23 +3,23 @@ import styled from 'styled-components';
 import { icHand, imgRoom } from 'assets';
 
 function FirstSection({ title, host }) {
-  if (title === 'unBooked') {
-    return (
-      <StyledFirstSection>
-        <StyledIcHand src={icHand} />
-        <span>아직 예약된 여행이 없습니다!</span>
-        <StyledSearchButton>숙소 검색하기</StyledSearchButton>
-      </StyledFirstSection>
-    );
-  } else {
-    return (
-      <StyledIsBooked>
-        <img src={imgRoom} />
-        <p>{title}</p>
-        <span>{host} 님이 호스팅 하는 집 전체</span>
-      </StyledIsBooked>
-    );
-  }
+  return (
+    <>
+      {title === 'unBooked' ? (
+        <StyledFirstSection>
+          <StyledIcHand src={icHand} />
+          <span>아직 예약된 여행이 없습니다!</span>
+          <StyledSearchButton>숙소 검색하기</StyledSearchButton>
+        </StyledFirstSection>
+      ) : (
+        <StyledIsBooked>
+          <img src={imgRoom} />
+          <p>{title}</p>
+          <span>{host} 님이 호스팅 하는 집 전체</span>
+        </StyledIsBooked>
+      )}
+    </>
+  );
 }
 
 export default FirstSection;
@@ -33,7 +33,7 @@ const StyledIsBooked = styled.section`
   background: #ffffff;
   border: 1px solid ${(props) => props.theme.colors.airGray2};
   border-radius: 1rem;
-  filter: drop-shadow(4px 4px 20px rgba(0, 0, 0, 0.15));
+  filter: drop-shadow(0.4rem 0.4rem 2rem rgba(0, 0, 0, 0.15));
 
   img {
     width: 32.9rem;
@@ -98,7 +98,7 @@ const StyledSearchButton = styled.button`
 
   width: 28.6rem;
   height: 4.4rem;
-  border-radius: 6px;
+  border-radius: 0.6rem;
 
   font-weight: 600;
   font-size: 1.6rem;

--- a/src/components/home/HomeInfo.jsx
+++ b/src/components/home/HomeInfo.jsx
@@ -1,15 +1,12 @@
 import styled from 'styled-components';
-import { icHand, imgChuncheon, imgSokcho, imgDaejeon } from 'assets';
+import { imgChuncheon, imgSokcho, imgDaejeon } from 'assets';
+import FirstSection from './FirstSection';
 
-function HomeInfo() {
+function HomeInfo({ title, host }) {
   return (
     <>
       <h1>예정된 예약</h1>
-      <StyledFirstSection>
-        <StyledIcHand src={icHand} />
-        <span>아직 예약된 여행이 없습니다!</span>
-        <StyledSearchButton>숙소 검색하기</StyledSearchButton>
-      </StyledFirstSection>
+      <FirstSection title={title} host={host} />
       <h2>이전 여행지</h2>
       <StyledSecondSection>
         <StyledImg>
@@ -19,15 +16,15 @@ function HomeInfo() {
         </StyledImg>
         <StyledInfo>
           <div>
-            <p>Geunhwa-dong,Chuncheon</p>
+            <p>Geunhwa-dong, Chuncheon</p>
             <span>2022년 1월 12일 - 2022년 1월 14일</span>
           </div>
           <div>
-            <p>joyang-dong,Sokcho</p>
+            <p>joyang-dong, Sokcho</p>
             <span>2021년 12월 5일 - 2021년 12월 6일</span>
           </div>
           <div>
-            <p>jayang-dong,Daejeon</p>
+            <p>jayang-dong, Daejeon</p>
             <span>2021년 6월 17일 - 2021년 7월 1일</span>
           </div>
         </StyledInfo>
@@ -37,51 +34,6 @@ function HomeInfo() {
 }
 
 export default HomeInfo;
-
-const StyledFirstSection = styled.section`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-
-  box-sizing: border-box;
-  width: 33.1rem;
-  height: 24.1rem;
-
-  background: #ffffff;
-  border: 1px solid ${(props) => props.theme.colors.airGray2};
-  border-radius: 1rem;
-
-  button {
-    background-color: ${(props) => props.theme.colors.airPink};
-    color: ${(props) => props.theme.colors.airWhite};
-  }
-
-  span {
-    margin-top: 2rem;
-
-    font-weight: 600;
-    font-size: 1.6rem;
-    line-height: 1.9rem;
-  }
-`;
-
-const StyledIcHand = styled.img`
-  width: 4rem;
-  height: 4rem;
-  margin-top: 4.8rem;
-`;
-
-const StyledSearchButton = styled.button`
-  margin-top: 4.8rem;
-
-  width: 28.6rem;
-  height: 4.4rem;
-  border-radius: 6px;
-
-  font-weight: 600;
-  font-size: 1.6rem;
-  line-height: 1.9rem;
-`;
 
 const StyledSecondSection = styled.section`
   display: flex;
@@ -111,7 +63,6 @@ const StyledImg = styled.div`
 const StyledInfo = styled.div`
   font-family: 'AirbnbCereal_W_Md';
 
-  width: 18.1rem;
   height: 22.4rem;
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;

--- a/src/components/room/RoomFooter.jsx
+++ b/src/components/room/RoomFooter.jsx
@@ -1,12 +1,15 @@
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 
-function RoomFooter({ price }) {
+function RoomFooter({ price, host, title }) {
   return (
     <StyledRoomFooter>
       <div>
         <span>₩{price}</span> / 박
       </div>
-      <button>예약하기</button>
+      <Link to={'/'} state={{ title: { title }, host: { host } }}>
+        <button>예약하기</button>
+      </Link>
     </StyledRoomFooter>
   );
 }

--- a/src/components/room/RoomFooter.jsx
+++ b/src/components/room/RoomFooter.jsx
@@ -7,7 +7,7 @@ function RoomFooter({ price, host, title }) {
       <div>
         <span>₩{price}</span> / 박
       </div>
-      <Link to="/" state={{ title: { title }, host: { host } }}>
+      <Link to="/" state={{ roomInfo: { title, host } }}>
         <button>예약하기</button>
       </Link>
     </StyledRoomFooter>

--- a/src/components/room/RoomFooter.jsx
+++ b/src/components/room/RoomFooter.jsx
@@ -7,7 +7,7 @@ function RoomFooter({ price, host, title }) {
       <div>
         <span>₩{price}</span> / 박
       </div>
-      <Link to={'/'} state={{ title: { title }, host: { host } }}>
+      <Link to="/" state={{ title: { title }, host: { host } }}>
         <button>예약하기</button>
       </Link>
     </StyledRoomFooter>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,11 +1,25 @@
 import styled from 'styled-components';
 import HomeInfo from 'components/home/HomeInfo';
 import NavBar from 'components/common/NavBar';
+import { useLocation } from 'react-router-dom';
 
 function Home() {
+  let title;
+  let host;
+
+  try {
+    const location = useLocation();
+    const state = location.state;
+    title = state.title.title;
+    host = state.host.host;
+  } catch (e) {
+    title = 'unBooked';
+    host = 'unBooked';
+  }
+
   return (
     <StyledHome>
-      <HomeInfo />
+      <HomeInfo title={title} host={host} />
       <NavBar />
     </StyledHome>
   );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -4,22 +4,12 @@ import NavBar from 'components/common/NavBar';
 import { useLocation } from 'react-router-dom';
 
 function Home() {
-  let title;
-  let host;
-
-  try {
-    const location = useLocation();
-    const state = location.state;
-    title = state.title.title;
-    host = state.host.host;
-  } catch (e) {
-    title = 'unBooked';
-    host = 'unBooked';
-  }
+  const location = useLocation();
+  const state = location.state;
 
   return (
     <StyledHome>
-      <HomeInfo title={title} host={host} />
+      <HomeInfo title={state?.roomInfo.title ?? 'unBooked'} host={state?.roomInfo.host ?? 'unBooked'} />
       <NavBar />
     </StyledHome>
   );

--- a/src/pages/Room.jsx
+++ b/src/pages/Room.jsx
@@ -21,14 +21,14 @@ function Room() {
     getRoomInfo();
   }, []);
 
-  const { image, price } = roomInfo;
+  const { image, price, host, title } = roomInfo;
 
   return (
     <StyledRoom>
       <RoomHeader />
       <img src={image} />
       <RoomInfo {...roomInfo} />
-      <RoomFooter price={price?.toLocaleString()} />
+      <RoomFooter host={host} title={title} price={price?.toLocaleString()} />
     </StyledRoom>
   );
 }

--- a/src/pages/WishList.jsx
+++ b/src/pages/WishList.jsx
@@ -3,6 +3,7 @@ import { client } from 'libs/api';
 import styled from 'styled-components';
 import React, { useState, useEffect } from 'react';
 import WishListInfo from 'components/wishlist/WishListInfo';
+import NavBar from 'components/common/NavBar';
 
 function WishList() {
   const [categoryList, setCategoryList] = useState([]);
@@ -17,10 +18,13 @@ function WishList() {
   }, []);
 
   return (
-    <StyledCategory>
-      <WishListHeader />
-      <WishListInfo list={categoryList} />
-    </StyledCategory>
+    <>
+      <StyledCategory>
+        <WishListHeader />
+        <WishListInfo list={categoryList} />
+      </StyledCategory>
+      <NavBar />
+    </>
   );
 }
 


### PR DESCRIPTION
## ✅ PR check list
- [x] PR 제목은 **[브랜치 이름] 작업 내용 한 줄 요약**으로 설정해 주세요.
- [x] develop branch로 요청했는지 확인해 주세요.
- [x] Reviewers, Assignees, Labels를 등록해 주세요.
- [x] PR이 승인된 경우 해당 브랜치는 삭제 부탁드립니다.
 
## 📋 작업 내용
- [x] 예약 기능 구현
- [x] 페이지 구조화 및 스타일링 

## 📌 PR Point
- Room 컴포넌트에서 가져온 props 들을 이용해서 RoomFooter의 예약하기 버튼을 눌렀을때 라우팅, useLocation Hook을 통해 Home/FirstSection 컴포넌트에 Room 의 title, host props 가 전달되며 Home 화면에서 해당하는 방의 정보를 렌더합니다.
- develop branch 의 코드를 머지하여 합친 코드입니다.
- 이제 문제는 예약하기 버튼을 눌렀을 때, 로딩화면이 떴다가 Home 으로 가야하는데, 이 중간에 로딩화면을 어떻게 넣어야 할지 고민...
- title, host props가 여기저기 좀 많이 이동하는 느낌,, ( Room -> RoomFooter -> Home -> HomeInfo -> FirstSection ) 과정을 간소화 할 방법이 어떤것들이 있을까?

## 📸 스크린샷 / GIF / 동영상

https://user-images.githubusercontent.com/97586683/169370133-639dae74-0e04-41e5-bfd5-422a9d699389.mp4


