### PR TITLE
[feat/bottom-sheet-wishlist] 바텀시트 내 위시리스트 조회 기능 구현

### DIFF
--- a/src/components/room/BottomSheet.jsx
+++ b/src/components/room/BottomSheet.jsx
@@ -35,6 +35,8 @@ const StyledBottomSheet = styled.div`
   position: fixed;
   width: min(42rem, 100%);
   height: fit-content;
+  max-height: 90%;
+  overflow-y: scroll;
   bottom: 0;
   border-radius: 1rem 1rem 0 0;
   background-color: ${(props) => props.theme.colors.airWhite};

--- a/src/components/room/BottomSheet.jsx
+++ b/src/components/room/BottomSheet.jsx
@@ -37,6 +37,9 @@ const StyledBottomSheet = styled.div`
   height: fit-content;
   max-height: 90%;
   overflow-y: scroll;
+  &::-webkit-scrollbar {
+    display: none;
+  }
   bottom: 0;
   border-radius: 1rem 1rem 0 0;
   background-color: ${(props) => props.theme.colors.airWhite};
@@ -48,6 +51,9 @@ const StyledBottomSheetHeader = styled.div`
   display: flex;
   align-items: center;
   border-bottom: 0.1rem solid ${(props) => props.theme.colors.airGray1};
+  position: sticky;
+  top: 0;
+  background: ${(props) => props.theme.colors.airWhite};
 
   & > img {
     cursor: pointer;

--- a/src/components/room/MiniWishListInfo.jsx
+++ b/src/components/room/MiniWishListInfo.jsx
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+
+function MiniWishListInfo({ list }) {
+  return (
+    <StyledMiniWishListInfo>
+      <StyledMiniCategoryInfo>
+        {list.map(({ id, image, title }) => (
+          <li key={id}>
+            <img src={image} />
+            <span>{title}</span>
+          </li>
+        ))}
+      </StyledMiniCategoryInfo>
+    </StyledMiniWishListInfo>
+  );
+}
+
+export default MiniWishListInfo;
+
+const StyledMiniWishListInfo = styled.div`
+  margin-top: 2.4rem;
+`;
+
+const StyledMiniCategoryInfo = styled.div`
+  display: flex;
+  gap: 2.4rem;
+  flex-direction: column;
+
+  li {
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 1.6rem;
+  }
+
+  li > span {
+    height: 1.7rem;
+    font-weight: 600;
+    font-size: 1.4rem;
+    line-height: 1.68rem;
+  }
+
+  img {
+    width: 5.8rem;
+    height: 5.8rem;
+    border-radius: 0.8rem;
+    object-fit: cover;
+  }
+`;

--- a/src/pages/Room.jsx
+++ b/src/pages/Room.jsx
@@ -7,6 +7,7 @@ import RoomFooter from 'components/room/RoomFooter';
 import BottomSheet from 'components/room/BottomSheet';
 import styled from 'styled-components';
 import { icPlus } from 'assets';
+import MiniWishListInfo from 'components/room/MiniWishListInfo';
 
 function Room() {
   const { id: roomID } = useParams();
@@ -15,6 +16,7 @@ function Room() {
   const [isModalOpen, setIsModalOpen] = useState(true);
   const [bottomSheetTitle, setBottomSheetTitle] = useState('위시리스트');
   const [name, setName] = useState('');
+  const [wishListInfo, setWishListInfo] = useState([]);
   const navigate = useNavigate();
 
   const getRoomInfo = async () => {
@@ -23,8 +25,14 @@ function Room() {
     setRoomInfo(data[roomID - 1]);
   };
 
+  const getWishListInfo = async () => {
+    const { data } = await client.get('/category');
+    setWishListInfo(data);
+  };
+
   useEffect(() => {
     getRoomInfo();
+    getWishListInfo();
   }, []);
 
   return (
@@ -43,7 +51,7 @@ function Room() {
                 </button>
                 <div>새로운 위시리스트 만들기</div>
               </StyledButtonWrapper>
-              {/* 여기에 기존 위시리스트 불러오기 */}
+              <MiniWishListInfo list={wishListInfo} />
             </StyledExistingWishList>
           ) : (
             <StyledNewWishList>


### PR DESCRIPTION
## ✅ PR check list
- [x] PR 제목은 **[브랜치 이름] 작업 내용 한 줄 요약**으로 설정해 주세요.
- [x] develop branch로 요청했는지 확인해 주세요.
- [x] Reviewers, Assignees, Labels를 등록해 주세요.
- [x] PR이 승인된 경우 해당 브랜치는 삭제 부탁드립니다.
 
## 📋 작업 내용
- [x] 바텀시트 내에서 위시리스트 정보 가져오기
- [x] 최대 높이 지정 후 데이터값이 최대 높이 넘어갈 시 스크롤 사용하게끔 구현

## 📌 PR Point
- 기존에 사용했던 위시리스트 가져오기 기능을 거의 그대로 사용, 디자인 부분만 조금 더 중점적으로 봐주시면 좋을 것 같아요! 특히 높이 지정 후에 스크롤 처리를 간단하게만 해봤는데 조금 어색하다거나 최대 높이가 좀 더 달랐으면 좋겠다 이런 의견도 좋습니다 ㅎㅎ!
- 이후 onClick이벤트를 설정할 때 서버 api가 필요해서 아직 이벤트는 설정안해두었습니다... 기억하기 쉽기 위해서 기록해놓는...ㅎㅎ

## 📸 스크린샷 / GIF / 동영상

https://user-images.githubusercontent.com/65010481/170529886-2ef02437-152e-43cd-ab15-b43fadeada93.mov


